### PR TITLE
Remove reference to absent code

### DIFF
--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -178,8 +178,6 @@ let squaresOfOdds xs =
     |> Seq.filter isOdd
 ```
 
-Notice the call to `Seq.toList`. That creates a list, which implements the <xref:System.Collections.ICollection> interface.
-
 There's one more step to go: square each of the odd numbers. Start by writing a new test:
 
 ```fsharp


### PR DESCRIPTION
## Summary

There is a reference to `Seq.toList` that was perhaps part of code in a previous version of the doc. However, it now seems not necessary, anymore, since it does not refer to any current code in the doc. Removing that said reference will make the doc more clear.
